### PR TITLE
Resolve relations to referenced resources when references follow a na…

### DIFF
--- a/swagger_to_uml.py
+++ b/swagger_to_uml.py
@@ -27,6 +27,9 @@ import yaml
 def resolve_ref(ref):
     return ref.split('/')[-1]
 
+def upcase_first_letter(s):
+    return s[0].upper() + s[1:]
+
 
 class Property:
     def __init__(self, name, type, required, example=None, description=None, default=None, enum=None, format=None,
@@ -83,6 +86,13 @@ class Property:
         # type is given or must be resolved from $ref
         if 'type' in type_dict:
             type_str = type_dict['type']
+
+            if type_str == "string" and 'format' in type_dict and type_dict['format'].endswith("ResourceId"):
+                ref_type = upcase_first_letter(type_dict['format'][0 : -10])
+
+            if type_str == "array" and 'items' in type_dict and 'type' in type_dict['items'] and "string" == type_dict['items']['type'] and 'format' in type_dict['items'] and type_dict['items']['format'].endswith("ResourceId"):
+                ref_type = upcase_first_letter(type_dict['items']['format'][0 : -10])
+
         elif '$ref' in type_dict:
             type_str = resolve_ref(type_dict['$ref'])
             ref_type = type_str


### PR DESCRIPTION
…ming convention.

**Example:** A theater play has serveral character roles. When creating or updating a `role` resource I want to include the back reference from role to play also in the payload. But I don't want to send the whole `play` payload. To model this relation I set the `playResourceId` within the `role` resource. 
I want this relation to be reflected also in my UML diagrams but cannot `$ref` the `play` resource in `role` because this would include the complete `play` resource JSON in `role`. That's why I just use the `playResourceId`. 

To be able to reflect this relationship in the UML I propose to search for `ResouceId` in the `format` string endings of the referencing resource. If found,  a relation between the referencing and the referenced resource (`role` and `play`) in this case is created. 


```
  Play:
    type: object
    properties:
      id:
        type: string
        format: uuid
      title:
        type: string
```

```
  Role:
    type: object
    properties:
      id:
        type: string
        format: uuid
      title:
        type: string
      playId:
        type: string
        format: playResourceId
```

Creates:
```
class Play {
    {field} string (uuid) id
    {field} string title
}
```

```
class Role {
    {field} string (uuid) id
    {field} string title
    {field} string (playResourceId) playId
}

Role ..> Play
```