### PR TITLE
:bug: fix issue with swagger 'allOf' keyword

### DIFF
--- a/swagger_to_uml.py
+++ b/swagger_to_uml.py
@@ -77,6 +77,8 @@ class Property:
             type_dict = d
         elif 'schema' in d:
             type_dict = d['schema']
+        elif 'allOf' in d and len(d['allOf']) > 0:
+            type_dict = d['allOf'][0]
         else:
             type_dict = {}
 
@@ -371,6 +373,8 @@ class Swagger:
             paths='\n\n'.join([d.uml for d in self.paths]),
             definitions='\n\n'.join([d.uml for d in self.definitions])
         )
+
+
 
 
 if __name__ == '__main__':

--- a/swagger_to_uml.py
+++ b/swagger_to_uml.py
@@ -375,8 +375,6 @@ class Swagger:
         )
 
 
-
-
 if __name__ == '__main__':
     input_file_name = sys.argv[1]
     sw = Swagger.from_file(input_file_name)


### PR DESCRIPTION
Open API 3.0 includes new keywords for combining schemas ```oneOf, anyOf, allOf```. This caused the```swagger_to_uml``` tool generated UML with undefined classes as follow ```<i>not specified</i>```

This PR fix the ```swagger_to_uml``` to consider the case when the ```allOf``` is used swagger definition, further work may be needed for the other keywords.