### PR TITLE
reference pointing to a different container ../..

### DIFF
--- a/bin/swagger_to_uml
+++ b/bin/swagger_to_uml
@@ -233,7 +233,10 @@ class Parameter:
     def from_dict(whole, d):
         ref = d.get('$ref')
         if ref != None:
-            d = whole['parameters'][resolve_ref(ref)]
+            d = whole
+            for k in ref.split('/'):
+                if k != '#':
+                    d = d[k]
         return Parameter(
             name=d['name'],
             location=d['in'],


### PR DESCRIPTION
Allow using the full path of reference.
For instance, APDS API spec parameters placed under **components/parameters**: https://github.com/parkingdata/spec/blob/6bd43ad31197c3aeb0149a9c08d3836c5be6a1dc/api/reference/APDS_API.yaml#L106
